### PR TITLE
Allow passing in custom -t when --napi is used

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -24,7 +24,7 @@ if (argv.all) {
 }
 
 // Should be the default once napi is stable
-if (argv.napi && !targets) {
+if (argv.napi && targets.length === 0) {
   targets = [
     abi.supportedTargets.filter(onlyNode).pop(),
     abi.supportedTargets.filter(onlyElectron).pop(),

--- a/bin.js
+++ b/bin.js
@@ -24,7 +24,7 @@ if (argv.all) {
 }
 
 // Should be the default once napi is stable
-if (argv.napi) {
+if (argv.napi && !targets) {
   targets = [
     abi.supportedTargets.filter(onlyNode).pop(),
     abi.supportedTargets.filter(onlyElectron).pop(),


### PR DESCRIPTION
If using `--napi` then `prebuildify` will always pick the latest node and electron. This patch allow you to do e.g. `prebuildify -t 8.1.40 -t electron@3.0.0 --napi`, i.e. you can pick any release strategy.

Background discussion: https://github.com/Level/leveldown/issues/553